### PR TITLE
fix: exclude mypy type check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,8 @@ repos:
     rev: v0.931
     hooks:
     -   id: mypy
+        # exclude, because mypy does not find types-requests stubs
+        exclude: ^(dev/|tests/unit/test_u_vault_backend.py)
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:


### PR DESCRIPTION
This PR addresses issue https://github.com/p15r/distributey/issues/116

Excluding `dev/` folder and `tests/unit/test_u_vault_backend.py` script, because mypy cannot find types-requests stubs
