### PR TITLE
fix: bump pycryptodomex to 3.19.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pycryptodomex==3.19.1
 Flask==2.3.2
+Werkzeug>=3.0
 gunicorn==20.1.0
 hvac==0.11.2
 pyjwt[crypto]==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycryptodomex==3.14.1
+pycryptodomex==3.19.1
 Flask==2.3.2
 gunicorn==20.1.0
 hvac==0.11.2

--- a/tests/unit/test_u_flask_app.py
+++ b/tests/unit/test_u_flask_app.py
@@ -278,7 +278,6 @@ class TestUnitFlaskApp():
              {'user-agent':
               ['User agent pattern does not match "name/version"']}}
         assert response.mimetype == 'application/json'
-        assert response.charset == 'utf-8'
 
     def test___x_real_ip_validator(
             self, http_client, get_endpoint_url, get_headers):


### PR DESCRIPTION
Bump pycryptodomex to 3.19.1, this addresses CVE-2023-52323 ([dependabot alert](https://github.com/p15r/distributey/security/dependabot/4))