### PR TITLE
fix: bump gunicorn to 22.0.0 to address CVE-2024-1135

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
     tmpfs:
       # default replay attack cache size of 10k requires approx. 324kb
       # for /tmp/cache.db
-      - /tmp:mode=770,size=1m
+      - /tmp:mode=0777,size=1m
     volumes:
       - ./config:/opt/distributey/config/:ro
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pycryptodomex==3.19.1
 Flask==2.3.2
 Werkzeug>=3.0
-gunicorn==20.1.0
+gunicorn==22.0.0
 hvac==0.11.2
 pyjwt[crypto]==2.4.0
 splunk-handler==3.0.0


### PR DESCRIPTION
This addresses https://github.com/p15r/distributey/security/dependabot/6